### PR TITLE
[FIX]-Add changes to three modules of project issues

### DIFF
--- a/project_issue_helpdesk/project_issue_helpdesk.py
+++ b/project_issue_helpdesk/project_issue_helpdesk.py
@@ -424,7 +424,7 @@ class StockPicking(orm.Model):
 
     def get_domain_issue_id(self,cr,uid,ids,partner_id,context=None):
         if partner_id:
-            issue_ids=self.pool.get('project.issue').search(cr,uid,['|',('branch_id','=',partner_id),('partner_id','=',partner_id)])
+            issue_ids=self.pool.get('project.issue').search(cr,uid,['|',('branch_id','=',partner_id),('partner_id','=',partner_id),('is_closed','=',False)])
             return {'domain':{'issue_id':[('id','in',issue_ids)]},'value':{'issue_id':False}}
         else:
             return {'domain':{'issue_id':False},'value':{'issue_id':False}}
@@ -440,7 +440,8 @@ class StockPicking(orm.Model):
         for picking in self.browse(cr, uid, ids, context=context):
             issue_ids=issue_obj.search(cr, uid, ['|',('branch_id','=',picking.partner_id.id),('partner_id','=',picking.partner_id.id)])
             for issue in issue_obj.browse(cr, uid, issue_ids, context=context):
-                picking_ids.append(issue.id)
+                if issue.is_closed==False:
+                    picking_ids.append(issue.id)
         res[picking.id]=picking_ids
         return res
     

--- a/project_issue_helpdesk/view/project_issue_helpdesk_view.xml
+++ b/project_issue_helpdesk/view/project_issue_helpdesk_view.xml
@@ -61,10 +61,10 @@
                     </page>
                 </xpath>
                 <xpath expr="/form/sheet[@string='Issue']/group/group[1]/div" position="after">
-                    <field name="categ_id" attrs="{'readonly':[('is_closed','=',True)]}" on_change="onchange_categ_id(categ_id)"/>
+                    <field name="categ_id" domain="[('supply_type','=','equipment')]" attrs="{'readonly':[('is_closed','=',True)]}" on_change="onchange_categ_id(categ_id)"/>
                 </xpath>
                 <field name="categ_id" position="after"> 
-                    <field name="product_id" domain="[('categ_id','=',categ_id)]" on_change="onchange_product_id(product_id)"/> 
+                    <field name="product_id" domain="[('categ_id','=',categ_id),('supply_type','=','equipment')]" on_change="onchange_product_id(product_id)"/> 
                 </field> 
                 <field name="product_id"  position="after"> 
                     <field name="prodlot_id" attrs="{'readonly':[('is_closed','=',True)]}" domain="[('product_id','=',product_id)]" on_change="onchange_prodlot_id(prodlot_id)"/> 

--- a/project_issue_helpdesk_invoicing/i18n/es.po
+++ b/project_issue_helpdesk_invoicing/i18n/es.po
@@ -280,7 +280,7 @@ msgstr "Días Feriados"
 #. module: project_issue_helpdesk_invoicing
 #: field:contract.pricelist,holiday_multiplier:0
 msgid "Holiday Multiplier"
-msgstr "Multiplicador de Horas Extras"
+msgstr "Multiplicador de Feriados"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:holiday.calendar.date,name:0

--- a/project_issue_helpdesk_invoicing/i18n/es.po
+++ b/project_issue_helpdesk_invoicing/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 8.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2015-04-30 19:17+0000\n"
-"PO-Revision-Date: 2015-04-30 19:17+0000\n"
+"POT-Creation-Date: 2015-05-13 22:49+0000\n"
+"PO-Revision-Date: 2015-05-13 22:49+0000\n"
 "Last-Translator: <>\n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -27,7 +27,7 @@ msgid "Add a notes..."
 msgstr "Agregar notas..."
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:389
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:398
 #, python-format
 msgid "Already exist a journal asiggned for warranty manufacturer.  (%s)"
 msgstr "Ya existe un diario asignado a garantías de fabricante.  (%s)"
@@ -35,7 +35,12 @@ msgstr "Ya existe un diario asignado a garantías de fabricante.  (%s)"
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_account_analytic_account
 msgid "Analytic Account"
-msgstr "Cuenta Analítica"
+msgstr "Cuenta analítica"
+
+#. module: project_issue_helpdesk_invoicing
+#: model:ir.model,name:project_issue_helpdesk_invoicing.model_account_analytic_line
+msgid "Analytic Line"
+msgstr "Línea analítica"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:account.journal,warranty_manufacturer:0
@@ -110,7 +115,7 @@ msgid "Contract ids"
 msgstr "Contratos"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:455
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:467
 #, python-format
 msgid "Contract only allow a product per line"
 msgstr "Contrato solo permite un producto por línea"
@@ -254,8 +259,8 @@ msgid "Generate issues for contracts of preventive check"
 msgstr "Generar incidencias para contratos de mantenimiento preventivo"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:475
 #: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:487
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:499
 #, python-format
 msgid "Generated for contract"
 msgstr "Generar por contrato"
@@ -280,7 +285,7 @@ msgstr "Días Feriados"
 #. module: project_issue_helpdesk_invoicing
 #: field:contract.pricelist,holiday_multiplier:0
 msgid "Holiday Multiplier"
-msgstr "Multiplicador de Feriados"
+msgstr "Multiplicador de Horas Extras"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:holiday.calendar.date,name:0
@@ -329,7 +334,7 @@ msgid "Interval Type"
 msgstr "Tipo de Intervalo"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:448
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:460
 #, python-format
 msgid "Interval number must be greater or equal to one"
 msgstr "El intervalo debe ser mayor o igaul a 1"
@@ -347,7 +352,7 @@ msgstr "Facturar contrato"
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_account_invoice_line
 msgid "Invoice Line"
-msgstr "Linea de Factura"
+msgstr "Línea de factura"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:project.task,invoice_id:0
@@ -370,8 +375,8 @@ msgid "Invoice type for preventive check and Periodic Rate"
 msgstr "Tipo de Facturación para mantenimientos preventivos y tarifas periodicas"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:390
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:226
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:392
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:289
 #, python-format
 msgid "Invoices"
 msgstr "Facturación"
@@ -384,7 +389,7 @@ msgstr "Números de factura"
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_account_invoice_report
 msgid "Invoices Statistics"
-msgstr "Estadísticas Facturas"
+msgstr "Estadísticas de facturas"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:project.task,extra:0
@@ -431,8 +436,8 @@ msgid "Issues Lines"
 msgstr "Líneas de incidencia"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:369
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:196
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:371
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:259
 #, python-format
 msgid "Issues to Invoice"
 msgstr "Incidencias a facturar"
@@ -463,6 +468,11 @@ msgid "Last Updated on"
 msgstr "Ultima actualización el"
 
 #. module: project_issue_helpdesk_invoicing
+#: field:res.company,maximum_description_product:0
+msgid "Maximum quantity of character in description of product"
+msgstr "Cantidad máxima permitida de caracteres en descripción del producto"
+
+#. module: project_issue_helpdesk_invoicing
 #: field:account.config.settings,maximum_name_task:0
 #: field:res.company,maximum_name_task:0
 msgid "Maximum quantity of character in name of task project"
@@ -485,7 +495,7 @@ msgid "Mount to Invoice"
 msgstr "Monto a facturar"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:305
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:307
 #, python-format
 msgid "Must configure a journal for warranty manufacturer"
 msgstr "Debe configurar un diario para las garantías de fabricante"
@@ -497,8 +507,8 @@ msgid "No Filter"
 msgstr "Sin filtros"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:72
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:79
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:75
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:82
 #, python-format
 msgid "Not branches in contract"
 msgstr "No hay sucursales para el contrato"
@@ -518,24 +528,31 @@ msgstr "Multiplicador de extras"
 #: selection:project.issue.helpdesk.invoice.wizard,filter:0
 #: selection:project.issue.invoice.account.wizard,filter:0
 msgid "Partner"
-msgstr "Cliente"
+msgstr "Empresa"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:55
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:58
 #, python-format
 msgid "Pending change status to done or paid of expense: %s"
 msgstr "Pendiente cambiar el estado a esperando pago o pagado a gasto: %s"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:52
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:417
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:55
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:429
+#, python-format
+msgid "Pending confirm delivery note for backorder: %s"
+msgstr "Pendiente confirmar nota de entrega para la transferencia: %s"
+
+#. module: project_issue_helpdesk_invoicing
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:53
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:427
 #, python-format
 msgid "Pending generate delivery note for backorder: %s"
 msgstr "Pendiente generar nota de entrega para transferencia: %s"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:50
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:415
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:51
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:425
 #, python-format
 msgid "Pending transfer the backorder: %s"
 msgstr "Pendiente realizar trasnferencia: %s"
@@ -553,9 +570,9 @@ msgid "Preventive Check and Periodic Rate"
 msgstr "Contratos Mantenimientos Preventivos y Tarifas Periodicas"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:473
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:474
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:485
 #: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:486
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:498
 #, python-format
 msgid "Preventive Check-"
 msgstr "Mantenimiento Preventivo-"
@@ -611,7 +628,7 @@ msgstr "Rentabilidad"
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_project_issue
 msgid "Project Issue"
-msgstr "Incidencia"
+msgstr "Incidencia proyecto"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:res.partner,is_provision:0
@@ -697,7 +714,7 @@ msgstr "Ordenes de venta y proyectos a facturar"
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_sale_order
 msgid "Sales Order"
-msgstr "Ordenes de venta"
+msgstr "Pedido de venta"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:project.issue.helpdesk.invoice.wizard,date_from:0
@@ -706,8 +723,8 @@ msgid "Start Date"
 msgstr "Fecha Inicial"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:397
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:233
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:399
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:296
 #, python-format
 msgid "Start Date must be less than End Date"
 msgstr "Fecha inicial debe ser menor que fecha final"
@@ -719,8 +736,8 @@ msgid "Start Period"
 msgstr "Período de inicio"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:402
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:238
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py:404
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:301
 #, python-format
 msgid "Start Period must be less than End Period"
 msgstr "Período inicial debe ser menor que el período final"
@@ -743,7 +760,7 @@ msgid "Task ids"
 msgstr "Tareas"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:40
+#: code:addons/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py:59
 #, python-format
 msgid "Task pending for close in the sale order %s"
 msgstr "Tareas pendientes por cerrar en la orden de venta %s"
@@ -754,17 +771,22 @@ msgid "Technical Rate"
 msgstr "Tarifa Experto"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:461
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:473
 #, python-format
 msgid "The date execute must be greater than the actual date"
-msgstr "LA fecha de ejecución debe ser mayor que fecha actual"
+msgstr "La fecha de ejecución debe ser mayor que fecha actual"
 
 #. module: project_issue_helpdesk_invoicing
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:399
-#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:421
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:408
+#: code:addons/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py:433
 #, python-format
 msgid "The task name exceeds the limit of %i characters."
 msgstr "El nombre de la tarea excede el límite de %i caracteres"
+
+#. module: project_issue_helpdesk_invoicing
+#: help:res.company,maximum_description_product:0
+msgid "This allows define the maximum quantity of character in description of product. If use value 0, the quantity is not limited "
+msgstr "Esto permite definir la cantidad máxima permitida de caracteres en descripción del producto. Si usa valor 0, la cantidad será ilimitada"
 
 #. module: project_issue_helpdesk_invoicing
 #: help:account.config.settings,maximum_name_task:0
@@ -775,7 +797,7 @@ msgstr "Permite definir la cantidad máxima de caracteres en el nombre de la tar
 #. module: project_issue_helpdesk_invoicing
 #: model:ir.model,name:project_issue_helpdesk_invoicing.model_hr_analytic_timesheet
 msgid "Timesheet Line"
-msgstr "Linea de registro de trabajo"
+msgstr "Línea de la hoja de servicios"
 
 #. module: project_issue_helpdesk_invoicing
 #: selection:project.issue.helpdesk.invoice.wizard,state:0
@@ -822,7 +844,7 @@ msgstr "Margen de variación(%)"
 #: field:account.invoice,variation_price:0
 #: field:account.invoice.line,variation_price:0
 msgid "Variation Price"
-msgstr ""
+msgstr "Variation Price"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:account.invoice,porcent_variation_price:0

--- a/project_issue_helpdesk_invoicing/i18n/es.po
+++ b/project_issue_helpdesk_invoicing/i18n/es.po
@@ -844,7 +844,7 @@ msgstr "Margen de variación(%)"
 #: field:account.invoice,variation_price:0
 #: field:account.invoice.line,variation_price:0
 msgid "Variation Price"
-msgstr "Variation Price"
+msgstr "Variación Precio"
 
 #. module: project_issue_helpdesk_invoicing
 #: field:account.invoice,porcent_variation_price:0

--- a/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py
+++ b/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py
@@ -342,11 +342,17 @@ class AccountInvoice(models.Model):
                         if backorder.invoice_state=='invoiced':
                             backorder.write({'invoice_state':'none'})
                             backorder.move_lines.write({'invoice_state':'none'})
+                            for delivery in backorder.delivery_note_id:
+                                if delivery.state=='invoiced' and len(delivery.invoice_ids)==1:
+                                    delivery.write({'state':'done'})
             for task in invoice.task_ids:
                 for backorder in task.backorder_ids:
                         if backorder.invoice_state=='invoiced':
                             backorder.write({'invoice_state':'none'})
                             backorder.move_lines.write({'invoice_state':'none'})
+                            for delivery in backorder.delivery_note_id:
+                                if delivery.state=='invoiced' and not len(delivery.invoice_ids)==1:
+                                    delivery.write({'state':'done'})
         return models.Model.unlink(self)
     task_ids=fields.One2many('project.task','invoice_id')
     issue_ids=fields.Many2many('project.issue','account_invoice_project_issue_rel',string='Issues')

--- a/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py
+++ b/project_issue_helpdesk_invoicing/project_issue_helpdesk_invoicing.py
@@ -46,10 +46,13 @@ class ProjectIssue(models.Model):
                 if type.closed==True:
                     for issue in issues:
                         for backorder in issue.backorder_ids:
-                            if backorder.state!='done':
-                                raise Warning(_('Pending transfer the backorder: %s' % backorder.name))
-                            elif not backorder.delivery_note_id:
-                                raise Warning(_('Pending generate delivery note for backorder: %s' % backorder.name))
+                            if backorder.picking_type_id.code=='outgoing':
+                                if backorder.state!='done':
+                                    raise Warning(_('Pending transfer the backorder: %s' % backorder.name))
+                                elif not backorder.delivery_note_id:
+                                    raise Warning(_('Pending generate delivery note for backorder: %s' % backorder.name))
+                                elif backorder.delivery_note_id.state=='draft':
+                                    raise Warning(_('Pending confirm delivery note for backorder: %s' % backorder.name))
                         for expense_line in issue.expense_line_ids:
                             if not expense_line.expense_id.state in ['done','pain']:
                                 raise Warning(_('Pending change status to done or paid of expense: %s' % expense_line.expense_id.name))
@@ -411,10 +414,13 @@ class ProjectTask(models.Model):
                 if type.closed==True:
                     for task in tasks:
                         for backorder in task.backorder_ids:
-                            if backorder.state!='done':
-                                raise Warning(_('Pending transfer the backorder: %s' % backorder.name))
-                            elif not backorder.delivery_note_id:
-                                raise Warning(_('Pending generate delivery note for backorder: %s' % backorder.name))
+                            if backorder.picking_type_id.code=='outgoing':
+                                if backorder.state!='done':
+                                    raise Warning(_('Pending transfer the backorder: %s' % backorder.name))
+                                elif not backorder.delivery_note_id:
+                                    raise Warning(_('Pending generate delivery note for backorder: %s' % backorder.name))
+                                elif backorder.delivery_note_id.state=='draft':
+                                    raise Warning(_('Pending confirm delivery note for backorder: %s' % backorder.name))
         user = self.pool.get('res.users').browse(cr, uid, uid, context=context)
         if 'name' in vals:
             if len(vals.get('name'))>user.company_id.maximum_name_task:

--- a/project_issue_helpdesk_invoicing/res_config.py
+++ b/project_issue_helpdesk_invoicing/res_config.py
@@ -25,8 +25,6 @@ class ResCompany(osv.Model):
     _inherit = 'res.company'
 
     _columns = {
-            'maximum_description_product': fields.integer('Maximum quantity of character in description of product',
-            help='This allows define the maximum quantity of character in description of product. If use value 0, the quantity is not limited '),
             'maximum_name_task': fields.integer('Maximum quantity of character in name of task project',
             help='This allows define the maximum quantity of character in name of task project. If use value 0, the quantity is not limited ')
             }

--- a/project_issue_helpdesk_invoicing/view/project_issue_helpdesk_invoicing.xml
+++ b/project_issue_helpdesk_invoicing/view/project_issue_helpdesk_invoicing.xml
@@ -102,8 +102,8 @@
                         <field name="pricelist_ids" colspan="4" nolabel="1" attrs="{'invisible': [('fix_price_invoices','=',False),('invoice_on_timesheets','=',False),('charge_expenses','=',False)]}">
                             <tree editable="top" string="Pricelist Lines">
                                 <field name="pricelist_line_type"/>
-                                <field name="categ_id" attrs="{'invisible':[('pricelist_line_type', '!=', 'category')]}"/>
-                                <field name="product_id" attrs="{'invisible':[('pricelist_line_type', '!=', 'product')]}"/>
+                                <field name="categ_id" domain="[('supply_type','=','equipment')]" attrs="{'invisible':[('pricelist_line_type', '!=', 'category')]}"/>
+                                <field name="product_id" domain="[('supply_type','=','equipment')]" attrs="{'invisible':[('pricelist_line_type', '!=', 'product')]}"/>
                                 <field name="technical_rate"/>
                                 <field name="assistant_rate"/>
                                 <field name="overtime_multiplier"/>
@@ -126,7 +126,7 @@
                         </p>
                         <field name="product_preventive_check_ids" colspan="4" nolabel="1" attrs="{'invisible': [('invoice_preventive_check','=',False)]}">
                             <tree editable="top" string="Product Lines">
-                                <field name="product_id" required="1"/>
+                                <field name="product_id" domain="[('supply_type','=','equipment')]" required="1"/>
                                 <field name="interval_number" required="1"/>
                                 <field name="interval_type" required="1"/>
                                 <field name="date_execute_issue" required="1" attrs="{'readonly': [('first_execute_issue','=',True)]}"/>

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
@@ -63,11 +63,8 @@ class IssueInvoiceWizard(models.TransientModel):
                                         'reference':timesheet.ticket_number,
                                         'price_subtotal':total_timesheet*quantity,
                                         'invoice_line_tax_id':[(6, 0, [tax.id for tax in account_line.product_id.taxes_id])],
+                                        'account_id':issue.product_id.property_account_income.id
                                         }
-                            if issue.branch_id and issue.partner_id:
-                                invoice_line['account_id']=issue.branch_id.property_account_receivable.id,
-                            elif not issue.branch_id and issue.partner_id:
-                                invoice_line['account_id']=issue.partner_id.property_account_receivable.id,
                             if issue.warranty=='seller':
                                 invoice_line['price_unit']=0
                             if count_lines<=limit_lines or limit_lines==0 or limit_lines==-1:
@@ -89,7 +86,7 @@ class IssueInvoiceWizard(models.TransientModel):
                                 count_lines+=1
                         account_line.write({'invoice_id':inv.id})
             for backorder in issue.backorder_ids:
-                if backorder.delivery_note_id and backorder.invoice_state!='invoiced' and backorder.state=='done':
+                if backorder.delivery_note_id and backorder.picking_type_id.code=='outgoing' and backorder.invoice_state!='invoiced' and backorder.state=='done':
                     for delivery_note_lines in backorder.delivery_note_id.note_lines:
                         if delivery_note_lines.note_id.currency_id.id != issue.analytic_account_id.company_id.currency_id.id:
                             import_currency_rate=delivery_note_lines.note_id.currency_id.get_exchange_rate(issue.analytic_account_id.company_id.currency_id,date.strftime(date.today(), "%Y-%m-%d"))[0]
@@ -106,11 +103,8 @@ class IssueInvoiceWizard(models.TransientModel):
                                     'invoice_line_tax_id':[(6, 0, [tax.id for tax in delivery_note_lines.taxes_id])],
                                     'account_analytic_id':issue.analytic_account_id.id,
                                     'reference':delivery_note_lines.note_id.name,
+                                    'account_id':delivery_note_lines.product_id.property_account_income.id
                                     }
-                        if issue.branch_id and issue.partner_id:
-                            invoice_line['account_id']=issue.branch_id.property_account_receivable.id,
-                        elif not issue.branch_id and issue.partner_id:
-                            invoice_line['account_id']=issue.partner_id.property_account_receivable.id,
                         if issue.warranty=='seller':
                             invoice_line['price_unit']=0
                         if line_detailed==True:
@@ -167,13 +161,16 @@ class IssueInvoiceWizard(models.TransientModel):
                                     import_currency_rate=expense_line.expense_id.currency_id.get_exchange_rate(lines.account_id.company_id.currency_id,date.strftime(date.today(), "%Y-%m-%d"))[0]
                                 else:
                                     import_currency_rate=1
+                                account_exp=lines.product_id.property_account_income.id
                                 total_expenses+=((lines.amount*-1)*import_currency_rate)*(100-factor.factor or 0.0) / 100.0
                                 lines.write({'invoice_id':inv.id})
             if total_expenses>0:
                 invoice_line={
                               'name': _(('Expenses of Issue #') + issue.issue_number),
+                              'real_quantity':1,
                               'quantity':1,
                               'price_unit':total_expenses,
+                              'account_id':account_exp
                               }
                 if issue.warranty=='seller':
                     invoice_line['price_unit']=0

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
@@ -86,7 +86,7 @@ class IssueInvoiceWizard(models.TransientModel):
                                 count_lines+=1
                         account_line.write({'invoice_id':inv.id})
             for backorder in issue.backorder_ids:
-                if backorder.delivery_note_id and backorder.picking_type_id.code=='outgoing' and backorder.invoice_state!='invoiced' and backorder.state=='done':
+                if backorder.delivery_note_id and backorder.delivery_note_id.state=='done' and backorder.picking_type_id.code=='outgoing' and backorder.invoice_state!='invoiced' and backorder.state=='done':
                     for delivery_note_lines in backorder.delivery_note_id.note_lines:
                         if delivery_note_lines.note_id.currency_id.id != issue.analytic_account_id.company_id.currency_id.id:
                             import_currency_rate=delivery_note_lines.note_id.currency_id.get_exchange_rate(issue.analytic_account_id.company_id.currency_id,date.strftime(date.today(), "%Y-%m-%d"))[0]
@@ -119,6 +119,7 @@ class IssueInvoiceWizard(models.TransientModel):
                                     inv_prod.write({'origin':inv_prod.origin + issue.issue_number +'-'})
                                 inv_prod.write({'invoice_line':[(0,0,invoice_line)]})
                                 inv_prod.write({'issue_ids':[(4,issue.id)]})
+                                backorder.delivery_note_id.write({'invoice_ids':[(4,inv_prod.id)]})
                                 count_lines_products+=1
                             else:
                                 if issue.issue_number not in inv_prod.origin:
@@ -130,6 +131,7 @@ class IssueInvoiceWizard(models.TransientModel):
                                     inv_prod.write({'origin':inv_prod.origin + issue.issue_number +'-'})
                                 inv_prod.write({'invoice_line':[(0,0,invoice_line)]})
                                 inv_prod.write({'issue_ids':[(4,issue.id)]})
+                                backorder.delivery_note_id.write({'invoice_ids':[(4,inv_prod.id)]})
                                 count_lines_products+=1
                         else:
                             if count_lines<=limit_lines or limit_lines==0 or limit_lines==-1:
@@ -137,6 +139,7 @@ class IssueInvoiceWizard(models.TransientModel):
                                     inv.write({'origin':inv.origin + issue.issue_number +'-'})
                                 inv.write({'invoice_line':[(0,0,invoice_line)]})
                                 inv.write({'issue_ids':[(4,issue.id)]})
+                                backorder.delivery_note_id.write({'invoice_ids':[(4,inv.id)]})
                                 count_lines+=1
                             else:
                                 if issue.issue_number not in inv.origin:
@@ -148,9 +151,11 @@ class IssueInvoiceWizard(models.TransientModel):
                                     inv.write({'origin':inv.origin + issue.issue_number +'-'})
                                 inv.write({'invoice_line':[(0,0,invoice_line)]})
                                 inv.write({'issue_ids':[(4,issue.id)]})
+                                backorder.delivery_note_id.write({'invoice_ids':[(4,inv.id)]})
                                 count_lines+=1
                         backorder.write({'invoice_state':'invoiced'})
                         backorder.move_lines.write({'invoice_state':'invoiced'})
+                        backorder.delivery_note_id.write({'state':'invoiced'})
             for expense_line in issue.expense_line_ids:
                 if expense_line.expense_id.state=='done':
                     for move_lines in expense_line.expense_id.account_move_id.line_id:

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_helpdesk_invoice_wizard.py
@@ -37,9 +37,16 @@ class IssueInvoiceWizard(models.TransientModel):
         count_lines_products=1
         first_line_product=0
         invoices_list=[]
+        cont_invoice=0
         limit_lines=user.company_id.maximum_invoice_lines
-        inv=invoice_obj.create(invoice_dict)
-        invoices_list.append(inv.id)
+        if line_detailed==True:
+            for issue in issues:
+                if issue.timesheet_ids or issue.expense_line_ids and cont_invoice==0:
+                    cont_invoice=1
+                    break
+        if cont_invoice==1 or line_detailed==False:
+            inv=invoice_obj.create(invoice_dict)
+            invoices_list.append(inv.id)
         for issue in issues:
             for timesheet in issue.timesheet_ids:
                 for account_line in timesheet.line_id:

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
@@ -53,8 +53,6 @@ class IssueInvoiceWizard(models.TransientModel):
                         count_lines=1
                         inv.write({'invoice_line':[(4,line_id[0])]})
                         count_lines+=1
-#         for invoice in invoice_obj.browse(invoice_id):
-#             for order in invoice.order_ids:
             for task in sale.task_ids:
                 if not task.invoice_id:
                     if task.is_closed==False:
@@ -122,9 +120,6 @@ class IssueInvoiceWizard(models.TransientModel):
                     'company_id': sale.company_id and sale.company_id.id or False,
                     'date_invoice': fields.date.today()
                 }
-                #inv_id = self.pool.get('account.invoice').create(cr, uid, inv)
-                #res_invoice=order_obj.action_invoice_create(self._cr,self._uid,sale.id, grouped=False, date_invoice=False)
-                #invoice_sale.append(res_invoice)
                 invoice_sale+=self.create_invoice_lines(inv,sale)
         return invoice_sale
     @api.multi

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
@@ -100,27 +100,26 @@ class IssueInvoiceWizard(models.TransientModel):
         invoice_sale=[]
         order_obj=self.pool.get('sale.order')
         for sale in sale_orders:
-            if not sale.invoice_exists:
-                if sale.partner_id and sale.partner_id.property_payment_term.id:
-                    pay_term = sale.partner_id.property_payment_term.id
-                else:
-                    pay_term = False
-                inv = {
-                    'name': sale.client_order_ref or '',
-                    'origin': sale.name,
-                    'type': 'out_invoice',
-                    'reference': "P%dSO%d" % (sale.partner_id.id, sale.id),
-                    'account_id': sale.partner_id.property_account_receivable.id,
-                    'partner_id': sale.partner_invoice_id.id,
-                    'currency_id' : sale.pricelist_id.currency_id.id,
-                    'comment': sale.note,
-                    'payment_term': pay_term,
-                    'fiscal_position': sale.fiscal_position.id or sale.partner_id.property_account_position.id,
-                    'user_id': sale.user_id and sale.user_id.id or False,
-                    'company_id': sale.company_id and sale.company_id.id or False,
-                    'date_invoice': fields.date.today()
-                }
-                invoice_sale+=self.create_invoice_lines(inv,sale)
+            if sale.partner_id and sale.partner_id.property_payment_term.id:
+                pay_term = sale.partner_id.property_payment_term.id
+            else:
+                pay_term = False
+            inv = {
+                'name': sale.client_order_ref or '',
+                'origin': sale.name,
+                'type': 'out_invoice',
+                'reference': "P%dSO%d" % (sale.partner_id.id, sale.id),
+                'account_id': sale.partner_id.property_account_receivable.id,
+                'partner_id': sale.partner_invoice_id.id,
+                'currency_id' : sale.pricelist_id.currency_id.id,
+                'comment': sale.note,
+                'payment_term': pay_term,
+                'fiscal_position': sale.fiscal_position.id or sale.partner_id.property_account_position.id,
+                'user_id': sale.user_id and sale.user_id.id or False,
+                'company_id': sale.company_id and sale.company_id.id or False,
+                'date_invoice': fields.date.today()
+            }
+            invoice_sale+=self.create_invoice_lines(inv,sale)
         return invoice_sale
     @api.multi
     def generate_preventive_check(self, contracts):
@@ -293,7 +292,7 @@ class IssueInvoiceWizard(models.TransientModel):
     @api.onchange('state')
     def get_account(self):
         if 'active_ids' in self._context and self._context.get('active_ids'):
-            self.sale_order_invoice_ids=self.env['sale.order'].search([('project_id','in',self._context.get('active_ids', False)),('state','=','manual'),('invoice_ids','=',False)])
+            self.sale_order_invoice_ids=self.env['sale.order'].search([('project_id','in',self._context.get('active_ids', False)),('state','=','manual')])
             self.contract_preventive_check_ids=self.env['account.analytic.account'].search([('id','in',self._context.get('active_ids', False)),('invoice_preventive_check','!=',False)])
     line_detailed=fields.Boolean(string="Product lines separate service lines",default=True)
     group_customer=fields.Boolean( string="Group by customer",default=True)

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
@@ -89,9 +89,12 @@ class IssueInvoiceWizard(models.TransientModel):
                                 if not account_line.invoice_id:
                                     account_line.write({'invoice_id':inv.id})
                         for backorder in task.backorder_ids:
-                            if backorder.delivery_note_id and backorder.invoice_state!='invoiced' and backorder.state=='done':
+                            if backorder.delivery_note_id and backorder.picking_type_id.code=='outgoing' and backorder.delivery_note_id.state=='done' and backorder.invoice_state!='invoiced' and backorder.state=='done':
                                 backorder.write({'invoice_state':'invoiced'})
                                 backorder.move_lines.write({'invoice_state':'invoiced'})
+                                backorder.delivery_note_id.write({'state':'invoiced'})
+                                for invoice in invoices_list:
+                                    backorder.delivery_note_id.write({'invoice_ids':[(4,invoice)]})
                         for expense_line in task.expense_line_ids:
                             if expense_line.expense_id.state=='done':
                                 for move_lines in expense_line.expense_id.account_move_id.line_id:

--- a/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
+++ b/project_issue_helpdesk_invoicing/wizard/project_issue_invoice_account_wizard.py
@@ -28,41 +28,74 @@ from dateutil.relativedelta import relativedelta
 
 class IssueInvoiceWizard(models.TransientModel):
     _name='project.issue.invoice.account.wizard'
-    def create_task_invoice_lines(self,invoice_id,sale):
+    def create_invoice_lines(self,invoice_dict,sales):
+        task_obj=self.pool.get('project.task')
         invoice_obj=self.env['account.invoice']
         sale_line=self.env['sale.order.line']
-        expenses_count=0
-        for invoice in invoice_obj.browse(invoice_id):
-            for order in invoice.order_ids:
-                for task in order.task_ids:
-                    if not task.invoice_id:
-                        if task.is_closed==False:
-                            raise Warning(_('Task pending for close in the sale order %s' %sale.name))
+        user = self.env['res.users'].browse(self._uid)
+        invoices_list=[]
+        count_lines=1
+        limit_lines=user.company_id.maximum_invoice_lines
+        inv=invoice_obj.create(invoice_dict)
+        sales.write({'invoice_ids':[(4,inv.id)]})
+        invoices_list.append(inv.id)
+        for sale in sales:
+            for line in sale.order_line:
+                if (not line.invoiced) and (line.state not in ('draft', 'cancel')):
+                    line_id = line.invoice_line_create()
+                    if count_lines<=limit_lines or limit_lines==0 or limit_lines==-1:
+                        inv.write({'invoice_line':[(4,line_id[0])]})
+                        count_lines+=1
+                    else:
+                        inv=invoice_obj.create(invoice_dict)
+                        sale.write({'invoice_ids':[(4,inv.id)]})
+                        invoices_list.append(inv.id)
+                        count_lines=1
+                        inv.write({'invoice_line':[(4,line_id[0])]})
+                        count_lines+=1
+#         for invoice in invoice_obj.browse(invoice_id):
+#             for order in invoice.order_ids:
+            for task in sale.task_ids:
+                if not task.invoice_id:
+                    if task.is_closed==False:
+                        raise Warning(_('Task pending for close in the sale order %s' %sale.name))
+                    else:
+                        invoice_line={
+                                    'name': task.name,
+                                    'quantity':1,
+                                    'price_unit':0,
+                                    'discount':sale.project_id.to_invoice.factor,
+                                    'account_analytic_id':sale.project_id.id,
+                                    'account_id': sale.partner_id.property_account_receivable.id,
+                                    'sequence':100
+                                    }
+                        if count_lines<=limit_lines or limit_lines==0 or limit_lines==-1:
+                            inv.write({'invoice_line':[(0,0,invoice_line)]})
+                            count_lines+=1
                         else:
-                            invoice_line={
-                                        'name': task.name,
-                                        'quantity':1,
-                                        'price_unit':0,
-                                        'discount':order.project_id.to_invoice.factor,
-                                        'account_analytic_id':order.project_id.id,
-                                        'account_id': order.partner_id.property_account_receivable.id,
-                                        }
-                            invoice.write({'invoice_line':[(0,0,invoice_line)]})
-                            for timesheet in task.timesheet_ids:
-                                for account_line in timesheet.line_id:
-                                    if not account_line.invoice_id:
-                                        account_line.write({'invoice_id':invoice.id})
-                            for backorder in task.backorder_ids:
-                                if backorder.delivery_note_id and backorder.invoice_state!='invoiced' and backorder.state=='done':
-                                    backorder.write({'invoice_state':'invoiced'})
-                                    backorder.move_lines.write({'invoice_state':'invoiced'})
-                            for expense_line in task.expense_line_ids:
-                                if expense_line.expense_id.state=='done':
-                                    for move_lines in expense_line.expense_id.account_move_id.line_id:
-                                        for lines in move_lines.analytic_lines:
-                                            if lines.account_id==expense_line.analytic_account and lines.name==expense_line.name and lines.unit_amount==expense_line.unit_quantity and (lines.amount*-1/lines.unit_amount)==expense_line.unit_amount and not lines.invoice_id:
-                                                lines.write({'invoice_id':invoice.id})
-                            task.write({'invoice_id':invoice.id})
+                            inv=invoice_obj.create(invoice_dict)
+                            sale.write({'invoice_ids':[(4,inv.id)]})
+                            invoices_list.append(inv.id)
+                            count_lines=1
+                            inv.write({'invoice_line':[(0,0,invoice_line)]})
+                            count_lines+=1
+                        
+                        for timesheet in task.timesheet_ids:
+                            for account_line in timesheet.line_id:
+                                if not account_line.invoice_id:
+                                    account_line.write({'invoice_id':inv.id})
+                        for backorder in task.backorder_ids:
+                            if backorder.delivery_note_id and backorder.invoice_state!='invoiced' and backorder.state=='done':
+                                backorder.write({'invoice_state':'invoiced'})
+                                backorder.move_lines.write({'invoice_state':'invoiced'})
+                        for expense_line in task.expense_line_ids:
+                            if expense_line.expense_id.state=='done':
+                                for move_lines in expense_line.expense_id.account_move_id.line_id:
+                                    for lines in move_lines.analytic_lines:
+                                        if lines.account_id==expense_line.analytic_account and lines.name==expense_line.name and lines.unit_amount==expense_line.unit_quantity and (lines.amount*-1/lines.unit_amount)==expense_line.unit_amount and not lines.invoice_id:
+                                            lines.write({'invoice_id':inv.id})
+                        task_obj.write(self._cr,self._uid,task.id,{'invoice_id':inv.id})
+        return invoices_list
     @api.multi
     def generate_invoice_sale_order(self, sale_orders):
         result={}
@@ -70,9 +103,29 @@ class IssueInvoiceWizard(models.TransientModel):
         order_obj=self.pool.get('sale.order')
         for sale in sale_orders:
             if not sale.invoice_exists:
-                res_invoice=order_obj.action_invoice_create(self._cr,self._uid,sale.id, grouped=False, date_invoice=False)
-                invoice_sale.append(res_invoice)
-                self.create_task_invoice_lines(res_invoice,sale)
+                if sale.partner_id and sale.partner_id.property_payment_term.id:
+                    pay_term = sale.partner_id.property_payment_term.id
+                else:
+                    pay_term = False
+                inv = {
+                    'name': sale.client_order_ref or '',
+                    'origin': sale.name,
+                    'type': 'out_invoice',
+                    'reference': "P%dSO%d" % (sale.partner_id.id, sale.id),
+                    'account_id': sale.partner_id.property_account_receivable.id,
+                    'partner_id': sale.partner_invoice_id.id,
+                    'currency_id' : sale.pricelist_id.currency_id.id,
+                    'comment': sale.note,
+                    'payment_term': pay_term,
+                    'fiscal_position': sale.fiscal_position.id or sale.partner_id.property_account_position.id,
+                    'user_id': sale.user_id and sale.user_id.id or False,
+                    'company_id': sale.company_id and sale.company_id.id or False,
+                    'date_invoice': fields.date.today()
+                }
+                #inv_id = self.pool.get('account.invoice').create(cr, uid, inv)
+                #res_invoice=order_obj.action_invoice_create(self._cr,self._uid,sale.id, grouped=False, date_invoice=False)
+                #invoice_sale.append(res_invoice)
+                invoice_sale+=self.create_invoice_lines(inv,sale)
         return invoice_sale
     @api.multi
     def generate_preventive_check(self, contracts):

--- a/project_task_helpdesk/view/project_task_helpdesk.xml
+++ b/project_task_helpdesk/view/project_task_helpdesk.xml
@@ -24,10 +24,10 @@
             <field name="priority" eval="50"/>
             <field name="arch" type="xml">
                  <field name="reviewer_id" position="after">
-                    <field name="categ_id" attrs="{'readonly':[('is_closed', '=', True)]}"/>
+                    <field name="categ_id" domain="[('supply_type','=','equipment')]" attrs="{'readonly':[('is_closed', '=', True)]}"/>
                 </field>
                 <field name="categ_id" position="after">
-                    <field name="product_id" domain="[('categ_id','=',categ_id)]" attrs="{'readonly':[('is_closed', '=', True)]}"/>
+                    <field name="product_id" domain="[('categ_id','=',categ_id),('supply_type','=','equipment')]" attrs="{'readonly':[('is_closed', '=', True)]}"/>
                 </field>
                 <field name="name" position="attributes">
                     <attribute name="attrs">{'readonly':[('is_closed', '=', True)]}</attribute>


### PR DESCRIPTION
Project Issue Helpdesk Invoicing
-Validate the quantity of invoice lines limit in invoicing of contracts of projects and sales order
-Permit invoicing of lines of sale order pending in contract
-Fix account_id for lines  of invoices, use account of products, not the account of partners
-Validate delivery notes have a state done for close the issues and tasks
-Remove state invoiced in delivery notes when draft invoices associated are deleted
-Add new terms of translate
-Add domain for show only products of type equipment in contracts
-Add domain for show only categories product of type equipment in contracts
-Fix bug of create blank invoice issues where the invoicing is
separate(products,services)

Project Issue Helpdesk
-Add domain for hidden issues closed in backorders
-Add domain for show only products of type equipmente in issues
-Add domain for show only categories product of type equipment in issues

Project Task Helpdesk
-Add domain for show only products of type equipmente in task
-Add domain for show only categories pro3 modulesduct of type equipment in task
