### PR TITLE
[REF] README: adapt description to new name

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ![Build Status](https://travis-ci.org/ClearCorp/odoo-clearcorp.svg?branch=9.0)
 
-odoo-clearcorp
+addons-clearcorp
 ==============
 
-Odoo CLEARCORP Apps
+Odoo CLEARCORP Apps (formerly odoo-clearcorp)


### PR DESCRIPTION
This module was moved from:
`ClearCorp/odoo-clearcorp` -> `Vauxoo/addons-ClearCorp`